### PR TITLE
too many enters fix

### DIFF
--- a/engine/battlehack20/engine/container/instrument.py
+++ b/engine/battlehack20/engine/container/instrument.py
@@ -175,17 +175,16 @@ class Instrument:
         for pair in pairs:
             num_instructions = pair[0] - previous_pair[0]
             num_lines = pair[1] - previous_pair[1]
-            while num_instructions > 255:
-                new_lnotab.append(255)
+            while num_instructions > 127:
+                new_lnotab.append(127)
                 new_lnotab.append(0)
-                num_instructions -= 255
+                num_instructions -= 127
             new_lnotab.append(num_instructions)
-            new_lnotab.append(min(num_lines, 255))
-            num_lines -= 255
-            while num_lines > 255:
+            while num_lines > 127:
+                new_lnotab.append(127)
                 new_lnotab.append(0)
-                new_lnotab.append(255)
-                num_lines -= 255
+                num_lines -= 127
+            new_lnotab.append(num_lines)
             previous_pair = pair
         #tranfer to bytes and we are good :)
         new_lnotab = bytes(new_lnotab)


### PR DESCRIPTION
If the source code has > 128 newlines in a row then the line number counting will have byte overflow which is a problem in the line number counting code. This PR fixes that