### PR TITLE
Add stubs

### DIFF
--- a/engine/battlehack20/engine/container/code_container.py
+++ b/engine/battlehack20/engine/container/code_container.py
@@ -61,7 +61,7 @@ class CodeContainer:
     @classmethod
     def preprocess(cls, content):
         """
-        Strips stub imports from the code.
+        Strips battlehack20.stubs imports from the code.
 
         It removes lines containing one of the following imports:
         - from battlehack20.stubs import *

--- a/engine/battlehack20/engine/container/code_container.py
+++ b/engine/battlehack20/engine/container/code_container.py
@@ -71,10 +71,10 @@ class CodeContainer:
         - from battlehack20.stubs import a,b,c
         - from  battlehack20.stubs  import  a,  b,  c
 
-        Go to https://regex101.com/r/bhAqFE/5 to test the regular expression with custom input.
+        Go to https://regex101.com/r/bhAqFE/6 to test the regular expression with custom input.
         """
 
-        pattern = r'^([ \t]*)from([ \t]+)battlehack20\.stubs([ \t]+)import([ \t]+)(\*|([a-zA-Z_]+([ \t]*),?([ \t]*))+)([ \t]*)$'
+        pattern = r'^([ \t]*)from([ \t]+)battlehack20\.stubs([ \t]+)import([ \t]+)(\*|([a-zA-Z_]+([ \t]*),([ \t]*))*[a-zA-Z_]+)([ \t]*)$'
 
         # Replace all stub imports
         while True:

--- a/engine/battlehack20/engine/container/code_container.py
+++ b/engine/battlehack20/engine/container/code_container.py
@@ -1,3 +1,4 @@
+import re
 from os import listdir
 from os.path import isfile, join
 from .instrument import Instrument
@@ -16,9 +17,9 @@ class CodeContainer:
 
         for filename in dic:
             module_name = filename.split('.py')[0]
-            compiled = compile_restricted(dic[filename], filename, 'exec')
+            compiled = compile_restricted(cls.preprocess(dic[filename]), filename, 'exec')
             code[module_name] = Instrument.instrument(compiled)
-        
+
         return cls(code)
 
     @classmethod
@@ -55,7 +56,39 @@ class CodeContainer:
     @classmethod
     def from_file(cls, filename):
         with open(filename, 'rb') as f:
-            return cls.from_bytes(f.read())
+            return cls.from_bytes(cls.preprocess(f.read()))
+
+    @classmethod
+    def preprocess(cls, content):
+        """
+        Strips stub imports from the code.
+
+        It removes lines containing one of the following imports:
+        - from battlehack20.stubs import *
+        - from battlehack20.stubs import a, b, c
+
+        The regular expression that is used also supports non-standard whitespace styles like the following:
+        - from battlehack20.stubs import a,b,c
+        - from  battlehack20.stubs  import  a,  b,  c
+
+        Go to https://regex101.com/r/bhAqFE/5 to test the regular expression with custom input.
+        """
+
+        pattern = r'^([ \t]*)from([ \t]+)battlehack20\.stubs([ \t]+)import([ \t]+)(\*|([a-zA-Z_]+([ \t]*),?([ \t]*))+)([ \t]*)$'
+
+        # Replace all stub imports
+        while True:
+            match = re.search(pattern, content, re.MULTILINE)
+
+            if match is None:
+                break
+
+            # Remove the match from the content
+            start = match.start()
+            end = match.end()
+            content = content[0:start] + content[end:]
+
+        return content
 
     def __getitem__(self, key):
         return self.code[key]

--- a/engine/battlehack20/stubs.py
+++ b/engine/battlehack20/stubs.py
@@ -1,0 +1,121 @@
+from typing import List, Optional, Tuple, Union
+
+from battlehack20.engine.game.game import Team, RobotType
+
+# The stubs in this file make it possible for editors to auto-complete the global methods
+# They can be imported using "from battlehack20.stubs import *"
+# This import is preprocessed away before instrumenting the code
+
+
+def log(msg: str) -> None:
+    """
+    Type-agnostic method.
+
+    Logs a message.
+    """
+    log(msg)
+
+
+def get_board_size() -> int:
+    """
+    Type-agnostic method.
+
+    Returns the board size.
+    """
+    return get_board_size()
+
+
+def get_bytecode() -> int:
+    """
+    Type-agnostic method.
+
+    Returns the number of bytecodes left.
+    """
+    return get_bytecode()
+
+
+def get_team() -> Team:
+    """
+    Type-agnostic method.
+
+    Returns the robot’s team, either `Team.WHITE` or `Team.BLACK`.
+    """
+    return get_team()
+
+
+def get_type() -> RobotType:
+    """
+    Type-agnostic method.
+
+    Returns the robot’s type, either `RobotType.OVERLORD` or `RobotType.PAWN`.
+    """
+    return get_type()
+
+
+def check_space(row: int, col: int) -> Union[Team, bool]:
+    """
+    Type-agnostic method.
+
+    Returns `False` if there is no robot at the location, the team of the robot if there is one there,
+    and throws a `RobotError` if outside the vision range.
+    """
+    return check_space(row, col)
+
+
+def get_board() -> List[List[Optional[Team]]]:
+    """
+    Overlord method.
+
+    Returns the current state of the board as an array of `Team.WHITE`, `Team.BLACK`, and `None`, representing
+    white-occupied, black-occupied, and empty squares, respectively.
+    """
+    return get_board()
+
+
+def spawn(row: int, col: int) -> None:
+    """
+    Overlord method.
+
+    Spawns a pawn at the given location, but throws a `RobotError` if the pawn is not spawned at the edge on your
+    side of the board, or if you have already spawned a pawn in this turn.
+    """
+    spawn(row, col)
+
+
+def capture(row: int, col: int) -> None:
+    """
+    Pawn method.
+
+    Captures an enemy piece at the given location, but throws a `RobotError` if the there is not an enemy pawn there
+    or if the location is not diagonally in front of you.
+    """
+    capture(row, col)
+
+
+def get_location() -> Tuple[int, int]:
+    """
+    Pawn method.
+
+    Returns a `(row, col)` tuple of the robot’s location.
+    """
+    return get_location()
+
+
+def move_forward() -> None:
+    """
+    Pawn method.
+
+    Moves forward one step, but throws a `RobotError` if you have already moved, if the location is outside the board
+    or if there is another pawn in front of you.
+    """
+    move_forward()
+
+
+def sense() -> List[Tuple[int, int, Team]]:
+    """
+    Pawn method.
+
+    Returns a list of tuples of the form `(row, col, robot.team)` visible to this robot (excluding yourself),
+    that is, if `max(|robot.x - other.x|, |robot.y - other.y|) <= 2`.
+    """
+    return sense()

--- a/engine/battlehack20/stubs.py
+++ b/engine/battlehack20/stubs.py
@@ -6,6 +6,9 @@ from battlehack20.engine.game.game import Team, RobotType
 # They can be imported using "from battlehack20.stubs import *"
 # This import is preprocessed away before instrumenting the code
 
+# The dummy implementations in this file exist so that editors won't give warnings like
+# "Assigning result of a function call, where the function has no return"
+
 
 def log(msg: str) -> None:
     """

--- a/engine/examplefuncsplayer/bot.py
+++ b/engine/examplefuncsplayer/bot.py
@@ -1,5 +1,6 @@
 import random
 
+from battlehack20.stubs import *
 
 # This is an example bot written by the developers!
 # Use this to help write your own code, or run it against your bot to see how well you can do!

--- a/specs/specs.md
+++ b/specs/specs.md
@@ -75,6 +75,8 @@ Below is a quick reference of all methods available to robots. Make sure not to 
 
 To view the implementation of these methods and the full list of what's available, check out [battlehack20/engine/game/game.py](https://github.com/battlecode/battlehack20/blob/master/engine/battlehack20/engine/game/game.py#L124).
 
+To get auto-completion on these methods in your editor (if your editor supports it), add `from battlehack20.stubs import *` to the top of the file. This import is removed before instrumenting your code, so it does not affect the bytecode your bot uses.
+
 #### Type-agnostic methods
 
 - `log()`: to print anything out, e.g. for debugging. Python's `print` will NOT work


### PR DESCRIPTION
Fixes #15.

This PR adds stubs for all robot methods in `battlehack20.stubs`. This makes it possible to do `from battlehack20.stubs import *`, after which editors recognize the global methods and can perform auto-completion on them. This import is stripped from the code when constructing a `CodeContainer` instance, so it does not affect the bytecode usage.