### PR TITLE
Remove restricted python's utility builtins

### DIFF
--- a/engine/battlehack20/engine/container/runner.py
+++ b/engine/battlehack20/engine/container/runner.py
@@ -64,7 +64,7 @@ class RobotRunner:
         self.instrument = Instrument(self)
         self.locals = {}
         self.globals = {
-            '__builtins__': dict(i for dct in [safe_builtins, limited_builtins, utility_builtins] for i in dct.items()),
+            '__builtins__': dict(i for dct in [safe_builtins, limited_builtins] for i in dct.items()),
             '__name__': '__main__'
         }
 
@@ -168,6 +168,10 @@ class RobotRunner:
             if name == 'random':
                 import random
                 return random
+            
+            if name == 'math':
+                import math
+                return math
 
             raise ImportError('Module "' + name + '" does not exist.')
 

--- a/engine/battlehack20/engine/container/runner.py
+++ b/engine/battlehack20/engine/container/runner.py
@@ -81,6 +81,8 @@ class RobotRunner:
 
         self.globals['__builtins__']['log'] = log_method
         self.globals['__builtins__']['enumerate'] = enumerate
+        self.globals['__builtins__']['set'] = set
+        self.globals['__builtins__']['frozenset'] = frozenset
 
         # instrumented methods
         self.globals['__builtins__']['sorted'] = self.instrument.instrumented_sorted


### PR DESCRIPTION
Now, `math` will need to be imported separately (and will be allowed) — thanks @gkanwar for pointing this out in #82 .

Fixes #82.