### PR TITLE
Remove pdb

### DIFF
--- a/engine/battlehack20/engine/container/runner.py
+++ b/engine/battlehack20/engine/container/runner.py
@@ -1,6 +1,5 @@
 import sys
 import traceback
-import pdb
 
 from RestrictedPython import safe_builtins, limited_builtins, utility_builtins, Guards
 from threading import Thread, Event
@@ -164,9 +163,6 @@ class RobotRunner:
             raise ImportError('No relative imports (yet).')
 
         if not name in self.code:
-            if self.debug and name == 'pdb':
-                return pdb
-
             if name == 'random':
                 import random
                 return random


### PR DESCRIPTION
It opens up the following exploit:

```
import pdb
from pdb import Pdb
class Hi:
    def write(self, x):
        pass
    def flush(self):
        pass
    def readline(self):
        return "c\n"
mypdb = pdb.Pdb(stdout = Hi(), stdin=Hi(), nosigint=True)
mypdb.run("import os")
mypdb.run("os.system(\"echo $BC20_GITKEY\")")
```

The fact that `pdb` might be a vulnerability was reported by a user who would like to remain anonymous.